### PR TITLE
Performance: Memory Optimizations

### DIFF
--- a/services/core/java/com/android/server/am/ActivityManagerConstants.java
+++ b/services/core/java/com/android/server/am/ActivityManagerConstants.java
@@ -20,6 +20,8 @@ import android.content.ContentResolver;
 import android.database.ContentObserver;
 import android.net.Uri;
 import android.os.Handler;
+import android.os.SystemProperties;
+import android.os.Process;
 import android.provider.Settings;
 import android.util.KeyValueListParser;
 import android.util.Slog;
@@ -67,7 +69,8 @@ final class ActivityManagerConstants extends ContentObserver {
     static final String KEY_BOUND_SERVICE_CRASH_RESTART_DURATION = "service_crash_restart_duration";
     static final String KEY_BOUND_SERVICE_CRASH_MAX_RETRY = "service_crash_max_retry";
 
-    private static final int DEFAULT_MAX_CACHED_PROCESSES = 32;
+    private static final int DEFAULT_MAX_CACHED_PROCESSES =
+            SystemProperties.getInt("ro.vendor.qti.sys.fw.bg_apps_limit", 32);
     private static final long DEFAULT_BACKGROUND_SETTLE_TIME = 60*1000;
     private static final long DEFAULT_FGSERVICE_MIN_SHOWN_TIME = 2*1000;
     private static final long DEFAULT_FGSERVICE_MIN_REPORT_TIME = 3*1000;
@@ -219,6 +222,17 @@ final class ActivityManagerConstants extends ContentObserver {
     // process limit.
     public int CUR_MAX_CACHED_PROCESSES;
 
+    static final boolean USE_TRIM_SETTINGS =
+            SystemProperties.getBoolean("ro.vendor.qti.sys.fw.use_trim_settings", true);
+    static final int EMPTY_APP_PERCENT =
+            SystemProperties.getInt("ro.vendor.qti.sys.fw.empty_app_percent", 50);
+    static final int TRIM_EMPTY_PERCENT =
+            SystemProperties.getInt("ro.vendor.qti.sys.fw.trim_empty_percent", 100);
+    static final int TRIM_CACHE_PERCENT =
+            SystemProperties.getInt("ro.vendor.qti.sys.fw.trim_cache_percent", 100);
+    static final long TRIM_ENABLE_MEMORY =
+            SystemProperties.getLong("ro.vendor.qti.sys.fw.trim_enable_memory", 1073741824);
+
     // The maximum number of empty app processes we will let sit around.
     public int CUR_MAX_EMPTY_PROCESSES;
 
@@ -253,7 +267,11 @@ final class ActivityManagerConstants extends ContentObserver {
     }
 
     public static int computeEmptyProcessLimit(int totalProcessLimit) {
-        return totalProcessLimit/2;
+        if (USE_TRIM_SETTINGS && allowTrim()) {
+            return totalProcessLimit * EMPTY_APP_PERCENT / 100;
+        } else {
+            return totalProcessLimit / 2;
+        }
     }
 
     @Override
@@ -339,8 +357,9 @@ final class ActivityManagerConstants extends ContentObserver {
         // to consider the same level the point where we do trimming regardless of any
         // additional enforced limit.
         final int rawMaxEmptyProcesses = computeEmptyProcessLimit(MAX_CACHED_PROCESSES);
-        CUR_TRIM_EMPTY_PROCESSES = rawMaxEmptyProcesses/2;
-        CUR_TRIM_CACHED_PROCESSES = (MAX_CACHED_PROCESSES-rawMaxEmptyProcesses)/3;
+        CUR_TRIM_EMPTY_PROCESSES = computeTrimEmptyApps(rawMaxEmptyProcesses);
+        CUR_TRIM_CACHED_PROCESSES = computeTrimCachedApps(
+                rawMaxEmptyProcesses, MAX_CACHED_PROCESSES);
     }
 
     void dump(PrintWriter pw) {
@@ -404,5 +423,25 @@ final class ActivityManagerConstants extends ContentObserver {
         pw.print("  CUR_MAX_EMPTY_PROCESSES="); pw.println(CUR_MAX_EMPTY_PROCESSES);
         pw.print("  CUR_TRIM_EMPTY_PROCESSES="); pw.println(CUR_TRIM_EMPTY_PROCESSES);
         pw.print("  CUR_TRIM_CACHED_PROCESSES="); pw.println(CUR_TRIM_CACHED_PROCESSES);
+    }
+
+    private static boolean allowTrim() {
+        return Process.getTotalMemory() < TRIM_ENABLE_MEMORY;
+    }
+
+    private static int computeTrimEmptyApps(int rawMaxEmptyProcesses) {
+        if (USE_TRIM_SETTINGS && allowTrim()) {
+            return rawMaxEmptyProcesses * TRIM_EMPTY_PERCENT / 100;
+        } else {
+            return rawMaxEmptyProcesses / 2;
+        }
+    }
+
+    private static int computeTrimCachedApps(int rawMaxEmptyProcesses, int totalProcessLimit) {
+        if (USE_TRIM_SETTINGS && allowTrim()) {
+            return totalProcessLimit * TRIM_CACHE_PERCENT / 100;
+        } else {
+            return (totalProcessLimit - rawMaxEmptyProcesses) / 3;
+        }
     }
 }


### PR DESCRIPTION
The following optimizations are squashed in this change.

1. Enable Aggressive trim settings.

This change will enable aggressive trim settings for targets
up to 1GB. The change can be turned on/off from system properties.
By default, the properties are set for targets up to 1GB.

Changes spread in to : ActivityManagerConstants.java
CRs-Fixed: 783020

2. Propagate B-services to higher adj.

Depending on the inactivity of a service, move the B-services to
highest adj 906. Under memory pressure, these services will
be killed first ahead of cached apps which results in better
concurrency numbers with bg apps. Inactivity time and minumum
no of services to be maintained are configurable as system properties.
Improves concurrency.

Changes spread in to : ActivityManagerService.java
CRs-Fixed: 792122

3. Postpone service restart during app launch.

In the android framework, when the service gets killed,
it will be rescheduled. Postpone the service restart if
the app is in process of startup. By Default this feature
is disabled. It can be enabled from build.prop of target.

Changes spread in to : ActiveServices.java
CRs-Fixed: 879756 911145

4. Performance: Make Cached apps limit configurable.

Set it via a target specific property
file. Allows flexibility to set the limit
based on device config.

Normally, setting a smaller value for
low-end device helps with performance.

Changes spread in to : ActivityManagerConstants.java

Squash of following change-IDs:
    Change-Id: I233dddbff07e7ec1fe2ee96402fe1d411903beb5
    Change-Id: Ied6cfcc3d11951f32f18de680b0e3483db8e163e
    Change-Id: Ia86edf027e20df2c7aa6f34e3aa293f7a8e6f1fa
    Change-Id: I90a733d7134d86efffadf6815ce3d2944dd09419

Change-Id: I3b2110743a6e0dd1379aa3b7703b3a897db3f6e6